### PR TITLE
Embed sprite images as Base64

### DIFF
--- a/engine/assets.py
+++ b/engine/assets.py
@@ -1,7 +1,47 @@
+"""Helpers for loading game assets such as images."""
+
 import os
+import base64
+import io
+
+import pygame
+
 from settings import ASSETS_DIR
 
 
+# Embedded sprites encoded as Base64 strings.  This avoids shipping the
+# binary PNG files with the project while still allowing easy access to the
+# images at runtime.
+EMBEDDED_SPRITES = {
+    "snake.png": (
+        "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGElEQVR4nGNk+M/wn4EIwESMolGF"
+        "1FMIADydAhILOWPNAAAAAElFTkSuQmCC"
+    ),
+    "food.png": (
+        "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAGElEQVR4nGP8z8Dwn4EIwESMolGF"
+        "1FMIAD2cAhK2AyPVAAAAAElFTkSuQmCC"
+    ),
+}
+
+
 def get_asset_path(*paths):
-    """Return absolute path to asset inside the assets directory."""
+    """Return absolute path to an asset inside the assets directory."""
     return os.path.join(ASSETS_DIR, *paths)
+
+
+def load_sprite(filename: str) -> pygame.Surface:
+    """Load a sprite image.
+
+    The function first checks for an embedded Base64 encoded sprite.  If
+    found, the data is decoded and loaded into a ``pygame.Surface`` with an
+    alpha channel.  Otherwise the sprite is loaded from disk inside the
+    ``assets`` directory.
+    """
+
+    if filename in EMBEDDED_SPRITES:
+        data = base64.b64decode(EMBEDDED_SPRITES[filename])
+        with io.BytesIO(data) as fh:
+            return pygame.image.load(fh).convert_alpha()
+
+    path = get_asset_path(filename)
+    return pygame.image.load(path).convert_alpha()

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import pygame
+import pytest
+
+# Ensure project root on path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from engine.assets import load_sprite
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _pygame_setup():
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    pygame.display.init()
+    pygame.display.set_mode((1, 1))
+    yield
+    pygame.quit()
+
+
+def test_load_snake_sprite_from_base64():
+    sprite = load_sprite("snake.png")
+    assert sprite.get_size() == (10, 10)
+    assert sprite.get_at((0, 0)) == pygame.Color(0, 255, 0, 255)
+
+
+def test_load_food_sprite_from_base64():
+    sprite = load_sprite("food.png")
+    assert sprite.get_size() == (10, 10)
+    assert sprite.get_at((0, 0)) == pygame.Color(255, 0, 0, 255)


### PR DESCRIPTION
## Summary
- Embed snake and food sprites as Base64 strings and load them without PNG files
- Add pygame-based loader to decode and handle embedded sprites
- Test sprite loading and colors using headless pygame

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68971f6b06d88327833ce8d922c275a5